### PR TITLE
Use Email header from SSOWat

### DIFF
--- a/sources/patches/x86-64-sso_auth.patch
+++ b/sources/patches/x86-64-sso_auth.patch
@@ -14,7 +14,7 @@ diff -Naur a/seahub/seahub/auth/middleware.py b/seahub/seahub/auth/middleware.py
                  " before the RemoteUserMiddleware class.")
          try:
 -            username = request.META[self.header]
-+            username = request.META["HTTP_REMOTE_USER"] + '@' + request.META["HTTP_HOST"]
++            username = request.META["HTTP_EMAIL"]
          except KeyError:
              # If specified header doesn't exist then return (leaving
              # request.user set to AnonymousUser by the


### PR DESCRIPTION
Fix #44

I think we may just want rewrite the `header` variable now in the patch ?

Tested it work like charm.

We need to add a note to WARN user because it will "break" SSO for wrongly created account with `username@seafiledomain` if the user haven't the email in the seafile domain.
