### PR TITLE
[buster] python-imaging ain't there anymore on buster, to replaced by python-pil

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -20,8 +20,8 @@ install_source() {
 }
 
 install_dependance() {
-	ynh_install_app_dependencies python2.7 python-pip libpython2.7 python-setuptools python-ldap python-urllib3 python-simplejson python-imaging python-mysqldb python-flup expect python-requests python-dev ffmpeg python-memcache \
-        libjpeg62-turbo-dev zlib1g-dev # For building pillow
+	ynh_install_app_dependencies "python2.7 python-pip libpython2.7 python-setuptools python-ldap python-urllib3 python-simplejson python-imaging|python-pil python-mysqldb python-flup expect python-requests python-dev ffmpeg python-memcache \
+        libjpeg62-turbo-dev zlib1g-dev" # For building pillow
     ynh_add_swap 2000
     # Note that we install imageio to force the dependance, without this imageio 2.8 is installed and it need python3.5
     sudo -u $seafile_user pip install --user --upgrade Pillow 'moviepy<1.0' 'imageio<2.8' certifi idna


### PR DESCRIPTION
Trying to install the deps : 

```
[...]
Package python-imaging is not available, but is referred to by another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
However the following packages replace it:
  python-pil
```

So this PR adds an 'or' to have compatibility with stretch and buster.

N.B. : didn't test the install of the app with this change ... maybe python-pil refers to Pillow and maybe that means it's not necessary to compile it on buster (c.f. the next lines about pip install Pillow), i dunno