### PR TITLE
feat(seahub): gunicorn redirect stdout and stderr

### DIFF
--- a/conf/gunicorn.conf.py
+++ b/conf/gunicorn.conf.py
@@ -4,6 +4,7 @@ import os
 
 daemon = True
 workers = 5
+enable_stdio_inheritance = True
 
 # default localhost:8000
 bind = "127.0.0.1:__PORT_SEAHUB__"


### PR DESCRIPTION
## Problem

Seahub was failing to start with no clear error message.

```logs
Starting Seafile hub...
LC_ALL is not set in ENV, set to fr_FR.UTF-8
/opt/seafile/seafile-server-11.0.12/seahub.sh: line 199: warning: setlocale: LC_ALL: cannot change locale (fr_FR.UTF-8)
Starting seahub at port 8000 ...
Error:Seahub failed to start.
Please try to run "./seahub.sh start" again
```
Despite the warning about `LC_ALL`, no indication of what went wrong. After digging directly `seahub.sh` and found the gunicorn config file, the [documentation](https://docs.gunicorn.org/en/stable/settings.html#enable-stdio-inheritance) mentioned that `enable_stdio_inheritance` is disabled by default. With `daemon = True` I think all gunicorn outputs goes to `/dev/null`.

## Solution

After enabling `enable_stdio_inheritance` for gunicorn I get a relevant log in journalctl :smiley: 
```logs
Starting Seafile hub...
LC_ALL is not set in ENV, set to fr_FR.UTF-8
/opt/seafile/seafile-server-11.0.12/seahub.sh: line 199: warning: setlocale: LC_ALL: cannot change locale (fr_FR.UTF-8)
Starting seahub at port 8000 ...
[2025-01-02 18:26:00 +0100] [3779208] [INFO] Starting gunicorn 20.1.0
Error: Already running on PID 2055 (or pid file '/opt/seafile/pids/seahub.pid' is stale)
Error:Seahub failed to start.
Please try to run "./seahub.sh start" again
```
In my case, `seahub.pid` wasn't deleted correctly after a unexpected shutdown. Easy to fix.

Also with `enable_stdio_inheritance = True`, we get a nice output in journalctl when all is good.

```logs
Starting Seafile hub...
LC_ALL is not set in ENV, set to fr_FR.UTF-8
/opt/seafile/seafile-server-11.0.12/seahub.sh: line 199: warning: setlocale: LC_ALL: cannot change locale (fr_FR.UTF-8)
Starting seahub at port 8000 ...
[2025-01-02 18:32:26 +0100] [3780392] [INFO] Starting gunicorn 20.1.0
[2025-01-02 18:32:26 +0100] [3780392] [INFO] Listening at: http://127.0.0.1:8000 (3780392)
[2025-01-02 18:32:26 +0100] [3780392] [INFO] Using worker: sync
[2025-01-02 18:32:26 +0100] [3780393] [INFO] Booting worker with pid: 3780393
[2025-01-02 18:32:26 +0100] [3780394] [INFO] Booting worker with pid: 3780394
[2025-01-02 18:32:27 +0100] [3780395] [INFO] Booting worker with pid: 3780395
[2025-01-02 18:32:27 +0100] [3780396] [INFO] Booting worker with pid: 3780396
[2025-01-02 18:32:27 +0100] [3780397] [INFO] Booting worker with pid: 3780397
Seahub is started
Done.
Started Seafile hub.
```

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)
