### PR TITLE
[autopatch] Autopatch to use timedatectl instead of legacy /etc/timezone

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -10,7 +10,7 @@ readonly seafile_image="$install_dir/seafile_image"
 readonly notification_image="$install_dir/notification_image"
 readonly seafile_code="$seafile_image/opt/seafile/seafile-server-$seafile_version"
 
-readonly time_zone="$(cat /etc/timezone)"
+readonly time_zone="$(timedatectl show --value --property=Timezone)"
 readonly python_version="$(python3 -V | cut -d' ' -f2 | cut -d. -f1-2)"
 systemd_seafile_bind_mount="$data_dir/seafile-data:/opt/seafile/seafile-data "
 systemd_seafile_bind_mount+="$data_dir/seahub-data:/opt/seafile/seahub-data "


### PR DESCRIPTION
This is an automatic PR

This is an ***automated*** fix to use the timedatectl command instead of
`cat /etc/timezone`.