### PR TITLE
Fix install when LANG=C

### DIFF
--- a/scripts/_common.sh
+++ b/scripts/_common.sh
@@ -32,7 +32,7 @@ else
     readonly path2="$path/"
 fi
 
-if [ "${LANG:0:2}" == C. ]; then
+if [ "${LANG:0:2}" == C. ] || [ "${LANG}" == C ]; then
     readonly language=en
 else
     readonly language="${LANG:0:2}"


### PR DESCRIPTION
## Problem

- https://forum.yunohost.org/t/seafile-installation-fails/37073

## Solution

- Fix lang when LANG=C

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)
